### PR TITLE
chore(ci): only run workflows when relevant files change

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,5 +1,17 @@
 name: Workflow for Codecov pandas-bootstrap
-on: [push, pull_request]
+on:
+  push:
+    paths:
+      - "bootstrap/**"
+      - "tests/**"
+      - "pyproject.toml"
+      - ".github/workflows/coverage.yml"
+  pull_request:
+    paths:
+      - "bootstrap/**"
+      - "tests/**"
+      - "pyproject.toml"
+      - ".github/workflows/coverage.yml"
 jobs:
   run:
     runs-on: ubuntu-latest

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,6 +4,11 @@ on:
     branches:
       - master
       - main
+    paths:
+      - "docs/**"
+      - "mkdocs.yml"
+      - ".github/workflows/docs.yml"
+      - "bootstrap/**"
 permissions:
   contents: write
 jobs:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,7 +1,13 @@
 name: Tests
 
 on:
-  - push
+  push:
+    paths:
+      - "bootstrap/**"
+      - "tests/**"
+      - "pyproject.toml"
+      - ".github/workflows/tests.yml"
+      - ".github/workflows/coverage.yml"
 
 jobs:
   test:


### PR DESCRIPTION
Closes #40

Add path filters to tests, docs, and coverage workflows so they
only trigger when the files they care about are modified.

- tests.yml runs on changes to bootstrap/, tests/, pyproject.toml, or CI config
- docs.yml runs on changes to docs/, mkdocs.yml, or bootstrap/
- coverage.yml runs on changes to source code